### PR TITLE
Add python 3 support

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,9 +11,9 @@ from cryptography.hazmat.primitives.asymmetric import padding
 import argparse
 import io
 
-kCrxFileHeaderMagic = "Cr24"
+kCrxFileHeaderMagic = b"Cr24"
 VERSION = struct.pack("<I", 3)
-kSignatureContext = 'CRX3 SignedData\00'
+kSignatureContext = b'CRX3 SignedData\00'
 fileBufferLength = 4096
 
 

--- a/main.py
+++ b/main.py
@@ -1,4 +1,3 @@
-import dircache
 import os
 import zipfile
 import crx3_pb2
@@ -105,7 +104,7 @@ def zipdir(directory, inject=None):
           fpath = '%s/%s' % (directory, fname)
           zf.writestr(fname, fdata)
 
-      for d in dircache.listdir(path):
+      for d in os.listdir(path):
         child = os.path.join(path, d)
         name = "%s/%s" % (parent, d)
         if os.path.isfile(child):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,5 @@
-asn1crypto==0.24.0
-cffi==1.11.5
-cryptography==2.5
-enum34==1.1.6
-ipaddress==1.0.22
-protobuf==3.6.1
+cffi==1.13.2
+cryptography==2.8
+protobuf==3.11.1
 pycparser==2.19
-six==1.12.0
+six==1.13.0


### PR DESCRIPTION
This updates `main.py` to work with python3. I replaced the usage of `dircache.listdir` with `os.listdir` because the `dircache` module was deprecated. I also updated `kCrxFileHeaderMagic` and `kSignatureContext` to be bytes objects. And finally updated the dependencies.

I verified this branch gives the same `sample.crx` with python 2 and 3. You can test this by comparing md5sum output by these 2 commands, with a `sample.pem` file already present.

python2
```
rm sample.crx || true && deactivate || true && mkvirtualenv -p /usr/bin/python2 crx3py2 &> /dev/null && pip install -r requirements.txt &> /dev/null && python main.py -pem sample.pem sample && md5sum sample.crx
```

python3
```
rm sample.crx || true && deactivate || true && mkvirtualenv -p /usr/bin/python3 crx3py3 && pip install -r requirements.txt && python main.py -pem sample.pem sample && md5sum sample.crx
```

This is a different result than what master gives because `os.listdir` returns directories in a different order compared with `dircache.listdir`. I tested this by running the snippet above for python2 with with only the f6682f0 change applied. And by comparing the output of `os.listdir` and `dircache.listdir` on the `sample` directory.
