### PR TITLE
Pep8 compliance

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,17 +2,14 @@ import os
 import zipfile
 import crx3_pb2
 import struct
-from cryptography.hazmat.backends import default_backend
-from cryptography.hazmat.primitives.asymmetric import rsa
-from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.primitives import hashes
-from cryptography.hazmat.primitives.asymmetric import utils
-from cryptography.hazmat.primitives.asymmetric import padding
 import argparse
 import io
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import serialization, hashes
+from cryptography.hazmat.primitives.asymmetric import rsa, utils, padding
 
-kCrxFileHeaderMagic = b"Cr24"
-VERSION = struct.pack("<I", 3)
+kCrxFileHeaderMagic = b'Cr24'
+VERSION = struct.pack('<I', 3)
 kSignatureContext = b'CRX3 SignedData\00'
 fileBufferLength = 4096
 
@@ -32,14 +29,14 @@ def create_publickey(private_key):
 
 def create_privatekey(path, crxd):
     if os.path.exists(path):
-        with open(path, "rb") as pf:
+        with open(path, 'rb') as pf:
             key = serialization.load_pem_private_key(
                 pf.read(), password=None, backend=default_backend()
             )
             pem = pf.read()
             return pem, key
-    pemfile = "%s.pem" % crxd
-    with open(pemfile, "wb") as pf:
+    pemfile = '%s.pem' % crxd
+    with open(pemfile, 'wb') as pf:
         private_key = rsa.generate_private_key(
             public_exponent=65537, key_size=2048, backend=default_backend()
         )
@@ -54,7 +51,7 @@ def create_privatekey(path, crxd):
 
 def package(basedir, private_key, output, files=None):
     if not os.path.isdir(basedir):
-        raise IOError("Non-existant directory <%s>" % basedir)
+        raise IOError('Non-existant directory <%s>' % basedir)
     crxd = rm_trailing_slash(basedir)
     try:
         zipdata = zipdir(crxd, inject=files)
@@ -73,7 +70,7 @@ def package(basedir, private_key, output, files=None):
 
 
 def sign(signed_header_data_str, zipped, private_key):
-    signed_header_size_octets = struct.pack("<I", len(signed_header_data_str))
+    signed_header_size_octets = struct.pack('<I', len(signed_header_data_str))
 
     chosen_hash = hashes.SHA256()
     hasher = hashes.Hash(chosen_hash, default_backend())
@@ -83,9 +80,9 @@ def sign(signed_header_data_str, zipped, private_key):
 
     for i in range(0, len(zipped), fileBufferLength):
         if i + fileBufferLength <= len(zipped):
-            hasher.update(zipped[i : i + fileBufferLength])
+            hasher.update(zipped[i: i + fileBufferLength])
         else:
-            hasher.update(zipped[i : len(zipped)])
+            hasher.update(zipped[i: len(zipped)])
 
     digest = hasher.finalize()
 
@@ -94,46 +91,45 @@ def sign(signed_header_data_str, zipped, private_key):
 
 def zipdir(directory, inject=None):
     zip_memory = io.BytesIO()
-    with zipfile.ZipFile(zip_memory, "w", zipfile.ZIP_DEFLATED) as zf:
+    with zipfile.ZipFile(zip_memory, 'w', zipfile.ZIP_DEFLATED) as zf:
 
-        def _rec_zip(path, parent="", inject=None):
+        def _rec_zip(path, parent='', inject=None):
             if inject:
                 for fname, fdata in inject.items():
-                    fpath = '%s/%s' % (directory, fname)
                     zf.writestr(fname, fdata)
 
             for d in os.listdir(path):
                 child = os.path.join(path, d)
-                name = "%s/%s" % (parent, d)
+                name = '%s/%s' % (parent, d)
                 if os.path.isfile(child):
                     zf.write(child, name)
                 if os.path.isdir(child):
                     _rec_zip(child, name)
 
-        _rec_zip(directory, "", inject=inject)
+        _rec_zip(directory, '', inject=inject)
         zf.close()
         zipdata = zip_memory.getvalue()
         return zipdata
-    raise IOError("Failed to create zip")
+    raise IOError('Failed to create zip')
 
 
 def argparser():
-    parser = argparse.ArgumentParser(description="crx3 creator")
+    parser = argparse.ArgumentParser(description='crx3 creator')
     parser.add_argument(
-        "src",
+        'src',
         type=str,
         default='',
-        help="Source directory containing unpacked chrome ext",
+        help='Source directory containing unpacked chrome ext',
     )
     parser.add_argument(
-        "-o", "--output", type=str, default='', help="File location for packed .crx"
+        '-o', '--output', type=str, default='', help='File location for packed .crx'
     )
     parser.add_argument(
-        "-pem",
-        "--private-key",
+        '-pem',
+        '--private-key',
         type=str,
         default='',
-        help="Private key location if no private key script will generate and save private key",
+        help='Private key location if no private key script will generate and save private key',
     )
     return parser
 
@@ -167,7 +163,7 @@ def create_header_str(public_key, signed, signed_header_data_str):
 
 
 def save_crx_file(header_str, zipped, path, crdx):
-    header_size_octets = struct.pack("<I", len(header_str))
+    header_size_octets = struct.pack('<I', len(header_str))
 
     fileLocation = path if path else '%s.crx' % crdx
     with open(fileLocation, 'wb') as crx:
@@ -176,5 +172,5 @@ def save_crx_file(header_str, zipped, path, crdx):
             crx.write(d)
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     cli()

--- a/main.py
+++ b/main.py
@@ -11,9 +11,9 @@ from cryptography.hazmat.primitives.asymmetric import padding
 import argparse
 import io
 
-kCrxFileHeaderMagic = "Cr24"
+kCrxFileHeaderMagic = b"Cr24"
 VERSION = struct.pack("<I", 3)
-kSignatureContext = 'CRX3 SignedData\00'
+kSignatureContext = b'CRX3 SignedData\00'
 fileBufferLength = 4096
 
 

--- a/main.py
+++ b/main.py
@@ -1,4 +1,3 @@
-import dircache
 import os
 import zipfile
 import crx3_pb2
@@ -105,7 +104,7 @@ def zipdir(directory, inject=None):
           fpath = '%s/%s' % (directory, fname)
           zf.writestr(fname, fdata)
 
-      for d in dircache.listdir(path):
+      for d in os.listdir(path):
         child = os.path.join(path, d)
         name = "%s/%s" % (parent, d)
         if os.path.isfile(child):

--- a/main.py
+++ b/main.py
@@ -18,156 +18,163 @@ fileBufferLength = 4096
 
 
 def rm_trailing_slash(d):
-  return d[:-1] if d.endswith(os.path.sep) else d
+    return d[:-1] if d.endswith(os.path.sep) else d
 
 
 def create_publickey(private_key):
-  public_key = private_key.public_key();
-  data = public_key.public_bytes(encoding=serialization.Encoding.DER,
-                                 format=serialization.PublicFormat.SubjectPublicKeyInfo)
-  return data
+    public_key = private_key.public_key()
+    data = public_key.public_bytes(
+        encoding=serialization.Encoding.DER,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return data
 
 
 def create_privatekey(path, crxd):
-  if os.path.exists(path):
-    with open(path, "rb") as pf:
-      key = serialization.load_pem_private_key(
-        pf.read(),
-        password=None,
-        backend=default_backend())
-      pem = pf.read()
-      return pem, key
-  pemfile = "%s.pem" % crxd
-  with open(pemfile, "wb") as pf:
-    private_key = rsa.generate_private_key(
-      public_exponent=65537,
-      key_size=2048,
-      backend=default_backend())
-    pem = private_key.private_bytes(
-      encoding=serialization.Encoding.PEM,
-      format=serialization.PrivateFormat.PKCS8,
-      encryption_algorithm=serialization.NoEncryption())
-    pf.write(pem)
-    return pem, private_key
+    if os.path.exists(path):
+        with open(path, "rb") as pf:
+            key = serialization.load_pem_private_key(
+                pf.read(), password=None, backend=default_backend()
+            )
+            pem = pf.read()
+            return pem, key
+    pemfile = "%s.pem" % crxd
+    with open(pemfile, "wb") as pf:
+        private_key = rsa.generate_private_key(
+            public_exponent=65537, key_size=2048, backend=default_backend()
+        )
+        pem = private_key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+        pf.write(pem)
+        return pem, private_key
 
 
 def package(basedir, private_key, output, files=None):
-  if not os.path.isdir(basedir):
-    raise IOError("Non-existant directory <%s>" % basedir)
-  crxd = rm_trailing_slash(basedir)
-  try:
-    zipdata = zipdir(crxd, inject=files)
-  except IOError as e:
-    raise e
+    if not os.path.isdir(basedir):
+        raise IOError("Non-existant directory <%s>" % basedir)
+    crxd = rm_trailing_slash(basedir)
+    try:
+        zipdata = zipdir(crxd, inject=files)
+    except IOError as e:
+        raise e
 
-  pem, private_key = create_privatekey(private_key, crxd)
-  public_key = create_publickey(private_key)
+    pem, private_key = create_privatekey(private_key, crxd)
+    public_key = create_publickey(private_key)
 
-  signed_header_data_str = create_signed_header_data_str(public_key)
+    signed_header_data_str = create_signed_header_data_str(public_key)
 
-  signed = sign(signed_header_data_str, zipdata, private_key)
-  header_str = create_header_str(public_key, signed, signed_header_data_str)
+    signed = sign(signed_header_data_str, zipdata, private_key)
+    header_str = create_header_str(public_key, signed, signed_header_data_str)
 
-  save_crx_file(header_str, zipdata, output, crxd)
+    save_crx_file(header_str, zipdata, output, crxd)
 
 
 def sign(signed_header_data_str, zipped, private_key):
-  signed_header_size_octets = struct.pack("<I", len(signed_header_data_str))
+    signed_header_size_octets = struct.pack("<I", len(signed_header_data_str))
 
-  chosen_hash = hashes.SHA256()
-  hasher = hashes.Hash(chosen_hash, default_backend())
-  hasher.update(kSignatureContext)
-  hasher.update(signed_header_size_octets)
-  hasher.update(signed_header_data_str)
+    chosen_hash = hashes.SHA256()
+    hasher = hashes.Hash(chosen_hash, default_backend())
+    hasher.update(kSignatureContext)
+    hasher.update(signed_header_size_octets)
+    hasher.update(signed_header_data_str)
 
-  for i in range(0, len(zipped), fileBufferLength):
-    if (i + fileBufferLength <= len(zipped)):
-      hasher.update(zipped[i: i + fileBufferLength])
-    else:
-      hasher.update(zipped[i: len(zipped)])
+    for i in range(0, len(zipped), fileBufferLength):
+        if i + fileBufferLength <= len(zipped):
+            hasher.update(zipped[i : i + fileBufferLength])
+        else:
+            hasher.update(zipped[i : len(zipped)])
 
-  digest = hasher.finalize()
+    digest = hasher.finalize()
 
-  return private_key.sign(
-    digest,
-    padding.PKCS1v15(),
-    utils.Prehashed(chosen_hash)
-  )
+    return private_key.sign(digest, padding.PKCS1v15(), utils.Prehashed(chosen_hash))
 
 
 def zipdir(directory, inject=None):
-  zip_memory = io.BytesIO()
-  with zipfile.ZipFile(zip_memory, "w", zipfile.ZIP_DEFLATED) as zf:
-    def _rec_zip(path, parent="", inject=None):
-      if inject:
-        for fname, fdata in inject.items():
-          fpath = '%s/%s' % (directory, fname)
-          zf.writestr(fname, fdata)
+    zip_memory = io.BytesIO()
+    with zipfile.ZipFile(zip_memory, "w", zipfile.ZIP_DEFLATED) as zf:
 
-      for d in os.listdir(path):
-        child = os.path.join(path, d)
-        name = "%s/%s" % (parent, d)
-        if os.path.isfile(child):
-          zf.write(child, name)
-        if os.path.isdir(child):
-          _rec_zip(child, name)
+        def _rec_zip(path, parent="", inject=None):
+            if inject:
+                for fname, fdata in inject.items():
+                    fpath = '%s/%s' % (directory, fname)
+                    zf.writestr(fname, fdata)
 
-    _rec_zip(directory, "", inject=inject)
-    zf.close()
-    zipdata = zip_memory.getvalue()
-    return zipdata
-  raise IOError("Failed to create zip")
+            for d in os.listdir(path):
+                child = os.path.join(path, d)
+                name = "%s/%s" % (parent, d)
+                if os.path.isfile(child):
+                    zf.write(child, name)
+                if os.path.isdir(child):
+                    _rec_zip(child, name)
+
+        _rec_zip(directory, "", inject=inject)
+        zf.close()
+        zipdata = zip_memory.getvalue()
+        return zipdata
+    raise IOError("Failed to create zip")
 
 
 def argparser():
-  parser = argparse.ArgumentParser(description="crx3 creator")
-  parser.add_argument("src", type=str, default='',
-                      help="Source directory containing unpacked chrome ext")
-  parser.add_argument("-o", "--output", type=str, default='',
-                      help="File location for packed .crx")
-  parser.add_argument("-pem", "--private-key", type=str, default='',
-                      help="Private key location if no private key script will generate and save private key")
-  return parser
+    parser = argparse.ArgumentParser(description="crx3 creator")
+    parser.add_argument(
+        "src",
+        type=str,
+        default='',
+        help="Source directory containing unpacked chrome ext",
+    )
+    parser.add_argument(
+        "-o", "--output", type=str, default='', help="File location for packed .crx"
+    )
+    parser.add_argument(
+        "-pem",
+        "--private-key",
+        type=str,
+        default='',
+        help="Private key location if no private key script will generate and save private key",
+    )
+    return parser
 
 
 def cli():
-  parser = argparser()
-  args = parser.parse_args()
-  package(args.src, args.private_key, args.output)
+    parser = argparser()
+    args = parser.parse_args()
+    package(args.src, args.private_key, args.output)
 
 
 def get_crx_id(public_key):
-  digest = hashes.Hash(hashes.SHA256(), backend=default_backend())
-  digest.update(public_key)
-  hased = digest.finalize()
-  return hased[0:16]
+    digest = hashes.Hash(hashes.SHA256(), backend=default_backend())
+    digest.update(public_key)
+    hased = digest.finalize()
+    return hased[0:16]
 
 
 def create_signed_header_data_str(public_key):
-  signed_header_data = crx3_pb2.SignedData()
-  signed_header_data.crx_id = get_crx_id(public_key)
-  return signed_header_data.SerializeToString()
+    signed_header_data = crx3_pb2.SignedData()
+    signed_header_data.crx_id = get_crx_id(public_key)
+    return signed_header_data.SerializeToString()
 
 
 def create_header_str(public_key, signed, signed_header_data_str):
-  header = crx3_pb2.CrxFileHeader()
-  proof = header.sha256_with_rsa.add()
-  proof.public_key = public_key
-  proof.signature = signed
-  header.signed_header_data = signed_header_data_str
-  return header.SerializeToString()
+    header = crx3_pb2.CrxFileHeader()
+    proof = header.sha256_with_rsa.add()
+    proof.public_key = public_key
+    proof.signature = signed
+    header.signed_header_data = signed_header_data_str
+    return header.SerializeToString()
 
 
 def save_crx_file(header_str, zipped, path, crdx):
-  header_size_octets = struct.pack("<I", len(header_str))
+    header_size_octets = struct.pack("<I", len(header_str))
 
-  fileLocation = path if path else '%s.crx' % crdx
-  with open(fileLocation, 'wb') as crx:
-    data = [kCrxFileHeaderMagic, VERSION, header_size_octets, header_str,
-            zipped]
-    for d in data:
-      crx.write(d)
+    fileLocation = path if path else '%s.crx' % crdx
+    with open(fileLocation, 'wb') as crx:
+        data = [kCrxFileHeaderMagic, VERSION, header_size_octets, header_str, zipped]
+        for d in data:
+            crx.write(d)
 
 
 if __name__ == "__main__":
-  cli()
+    cli()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,5 @@
-asn1crypto==0.24.0
-cffi==1.11.5
-cryptography==2.5
-enum34==1.1.6
-ipaddress==1.0.22
-protobuf==3.6.1
+cffi==1.13.2
+cryptography==2.8
+protobuf==3.11.1
 pycparser==2.19
-six==1.12.0
+six==1.13.0


### PR DESCRIPTION
NB: this is based on #1 which should be merged before this.

I ran [`black -S`](https://github.com/psf/black) on `main.py` 3c318ca

Then I manually made some small style changes. I consolidated the imports and homogenized all strings to use `'` (no more `"`)  cd6a30d
